### PR TITLE
Removing creds

### DIFF
--- a/LogParser/package/config.py
+++ b/LogParser/package/config.py
@@ -7,7 +7,5 @@ MYSQL_CONFIG = {
 
 AWS_CONFIG = {
     'bucket': 'cti-developer-dropbox',
-    'region': 'us-east-1',
-    'key': 'AKIAJMV3SLJRPTLSLALQ',
-    'secret': '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'
+    'region': 'us-east-1'
 }


### PR DESCRIPTION
AWS credentials should never be stored in code. Use roles or the credentials file from the AWS CLI via the AWS SDK.